### PR TITLE
Alteração para exibição de dados simulados

### DIFF
--- a/src/components/Scroll.tsx
+++ b/src/components/Scroll.tsx
@@ -18,7 +18,7 @@ export const Scroll = ({
   const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
     if (href.startsWith("#")) {
       e.preventDefault();
-      const elementoAlvo = document.querySelector(href);
+      const elementoAlvo = document.getElementById(href.substring(1));
       if (elementoAlvo) {
         elementoAlvo.classList.add("highlight");
         setTimeout(() => {


### PR DESCRIPTION
Apesar da API ainda não estar sendo integrada completamente, foi analisado em log que está sendo captado os resultados da busca da API, porém, ele está pegando dados anteriores, com a limitação de uma predição de dados futuros, o que faz que seja levantado uma exceção que use dados simulados. É interessante fazer um processo de cálculo de predição utilizando a média dos meses passados da mesma quantidade do que for inserido de pretensão do usuário (basicamente, se ele quiser investir 6 meses, utilizar a média de 6 meses anteriores para fazer o cálculo futuro), apenas uma sugestão. Até porque ele está pegando os dados passados. Porém, apesar dessas complicações, a exibição dos resultados com dados simulados está sendo um grande progresso que estou trazendo nesse merge.